### PR TITLE
Add dnsLookup option to allow custom blacklist/whitelist logic

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -286,9 +286,7 @@ function getHandler(options, proxy) {
     setHeaders: {},                 // Set these request headers.
     corsMaxAge: 0,                  // If set, an Access-Control-Max-Age header with this value (in seconds) will be added.
     helpFile: __dirname + '/help.txt',
-    dnsLookup: function(hostname, callback) {
-      dns.lookup(hostname, {hints: dns.ADDRCONFIG}, callback);
-    },
+    dnsLookup: null,
   };
 
   Object.keys(corsAnywhere).forEach(function(option) {

--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+var dns = require('dns');
 var httpProxy = require('http-proxy');
 var net = require('net');
 var url = require('url');
@@ -84,7 +85,7 @@ function proxyRequest(req, res, proxy) {
   var proxyOptions = {
     changeOrigin: false,
     prependPath: false,
-    target: location,
+    target: location.href,
     headers: {
       host: location.host,
     },
@@ -132,7 +133,24 @@ function proxyRequest(req, res, proxy) {
 
   // Start proxying the request
   try {
-    proxy.web(req, res, proxyOptions);
+    if (!req.corsAnywhereRequestState.dnsLookup) {
+      // Start proxying the request
+      proxy.web(req, res, proxyOptions);
+      return;
+    }
+    var targetUrl = url.parse(proxyOptions.target);
+    req.corsAnywhereRequestState.dnsLookup(targetUrl.hostname, function (err, address) {
+      if (err) {
+        // TODO: Should errors just be propagated, or should we support something like
+        // err.statusCode, err.statusText and err.message to customize the HTTP response?
+        proxy.emit('error', err, req, res);
+        return;
+      }
+      targetUrl.host = null; // Null .host so that .hostname + .port is used.
+      targetUrl.hostname = address;
+      proxyOptions.target = url.format(targetUrl);
+      proxy.web(req, res, proxyOptions);
+    });
   } catch (err) {
     proxy.emit('error', err, req, res);
   }
@@ -268,6 +286,9 @@ function getHandler(options, proxy) {
     setHeaders: {},                 // Set these request headers.
     corsMaxAge: 0,                  // If set, an Access-Control-Max-Age header with this value (in seconds) will be added.
     helpFile: __dirname + '/help.txt',
+    dnsLookup: function(hostname, callback) {
+      dns.lookup(hostname, {hints: dns.ADDRCONFIG}, callback);
+    },
   };
 
   Object.keys(corsAnywhere).forEach(function(option) {
@@ -299,6 +320,7 @@ function getHandler(options, proxy) {
       getProxyForUrl: corsAnywhere.getProxyForUrl,
       maxRedirects: corsAnywhere.maxRedirects,
       corsMaxAge: corsAnywhere.corsMaxAge,
+      dnsLookup: corsAnywhere.dnsLookup,
     };
 
     var cors_headers = withCORS({}, req);

--- a/server.js
+++ b/server.js
@@ -57,10 +57,12 @@ cors_proxy.createServer({
       '192.168.',
       'fe80::10'
     ];
-    if (excludedHostnamePrefixes.some(p => hostname.startsWith(p))) {
-      throw new Error();
-    }
-    dns.lookup(hostname, {hints: dns.ADDRCONFIG}, callback);
+    dns.lookup(hostname, { hints: dns.ADDRCONFIG }, (err, address, family) => {
+      if (excludedHostnamePrefixes.some(p => address.startsWith(p))) {
+        err = 'ExcludedAddress'
+      }
+      callback(err, address, family);
+    });
   },
 }).listen(port, host, function() {
   console.log('Running CORS Anywhere on ' + host + ':' + port);

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ var cors_proxy = require('./lib/cors-anywhere');
 cors_proxy.createServer({
   originBlacklist: originBlacklist,
   originWhitelist: originWhitelist,
+  requireHeader: ['origin', 'x-requested-with'],
   checkRateLimit: checkRateLimit,
   removeHeaders: [
     'cookie',


### PR DESCRIPTION
As described in [this upstream issue](https://github.com/Rob--W/cors-anywhere/issues/78), this PR introduces a `dnsLookup` configuration option which allows for custom logic to whitelist or blacklist requests to specific hostnames.

To test the change, start the server locally and check that hostnames starting with loopback or site local IPs are blocked.
