### PR TITLE
Ensure `address` is defined before checking against an excluded hostname prefix

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ cors_proxy.createServer({
       'fe80::10'
     ];
     dns.lookup(hostname, { hints: dns.ADDRCONFIG }, (err, address, family) => {
-      if (excludedHostnamePrefixes.some(p => address.startsWith(p))) {
+      if (address && excludedHostnamePrefixes.some(p => address.startsWith(p))) {
         err = 'ExcludedAddress'
       }
       callback(err, address, family);


### PR DESCRIPTION
DNS failed for the corsproxy instance and resulted in runtime error from the `dnsLookup` function.

This change adds a protection against an undefined `address` value, which kills the instance.